### PR TITLE
Support deep imports and multiple imports from the same module

### DIFF
--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -21,6 +21,18 @@ describe("installer", function() {
         expect(installer.check(["does-not-exist"])).toEqual(["does-not-exist"]);
       });
 
+      context("that import deeply", function() {
+        it("should return their module name", function() {
+          expect(installer.check(["does-not-exist/lib/test"])).toEqual(["does-not-exist"]);
+        });
+      });
+
+      context("that import multiple times from the same module", function() {
+        it("should return their module name once", function() {
+          expect(installer.check(["d-n-e/a", "d-n-e/b"])).toEqual(["d-n-e"]);
+        });
+      });
+
       context("that exists in alternative directories", function() {
         it("should return []", function() {
           expect(installer.check(["test"], [process.cwd()])).toEqual([]);


### PR DESCRIPTION
The whole dependency name check was excluding imports which use `/` for deep imports - replaced it with a check for a leading `.`

Also ensured `check()` will only return a missing module name once. This probably doesn't matter for generating the npm install command, but also saves duplicating the same filesystem checks.