### PR TITLE
Use --save or --save-exact flags when installing based on loader query config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ save=true
 
 This will automatically save any dependencies anytime you run `npm install` (no need to pass `--save`).
 
+**Alternatively**, you can provide CLI arguments that get added directly to `npm install`:
+
+```js
+postLoaders: [
+  {
+    exclude: /node_modules/,
+    loader: "npm-install-loader",
+    query: {
+      cli: {
+        registry: "..."   // --registry='...'
+        save: true,       // --save
+        saveExact: true,  // --save-exact
+      },
+    },
+    test: /\.js$/,
+  },
+],
+
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/ericclemmons/webpack-npm-install-loader#readme",
   "dependencies": {
-    "babel-core": "^6.3.26"
+    "babel-core": "^6.3.26",
+    "lodash.kebabcase": "^3.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/ericclemmons/webpack-npm-install-loader#readme",
   "dependencies": {
     "babel-core": "^6.3.26",
+    "loader-utils": "^0.2.12",
     "lodash.kebabcase": "^3.0.1"
   },
   "devDependencies": {

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,6 +1,8 @@
 var installer = require("./installer");
+var loaderUtils = require("loader-utils");
 var path = require("path");
 var parser = require("./parser");
+var util = require("util");
 
 module.exports = function loader(source, map) {
   if (this.cacheable) {
@@ -20,8 +22,9 @@ module.exports = function loader(source, map) {
   });
 
   var missing = installer.check(dependencies, modulePaths);
+  var query = loaderUtils.parseQuery(this.query);
 
-  installer.install(missing);
+  installer.install(missing, query.cli);
 
   this.callback(null, source, map);
 };

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -74,11 +74,8 @@ describe("installer", function() {
 
         expect(this.spy).toHaveBeenCalled();
         expect(this.spy.calls.length).toEqual(1);
-        expect(this.spy.calls[0].arguments).toEqual([
-          "npm",
-          ["install", "foo", "bar"],
-          { "stdio": "inherit" },
-        ]);
+        expect(this.spy.calls[0].arguments[0]).toEqual("npm");
+        expect(this.spy.calls[0].arguments[1]).toEqual(["install", "foo", "bar"]);
       });
     });
   });

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -77,6 +77,27 @@ describe("installer", function() {
         expect(this.spy.calls[0].arguments[0]).toEqual("npm");
         expect(this.spy.calls[0].arguments[1]).toEqual(["install", "foo", "bar"]);
       });
+
+      context("given options", function() {
+        it("should pass them to child process", function() {
+          var result = installer.install(["foo", "bar"], {
+            save: true,
+            saveExact: false,
+            registry: "https://registry.npmjs.com/",
+          });
+
+          expect(this.spy).toHaveBeenCalled();
+          expect(this.spy.calls.length).toEqual(1);
+          expect(this.spy.calls[0].arguments[0]).toEqual("npm");
+          expect(this.spy.calls[0].arguments[1]).toEqual([
+            "install",
+            "foo",
+            "bar",
+            "--save",
+            "--registry='https://registry.npmjs.com/'",
+          ]);
+        });
+      });
     });
   });
 });

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -7,6 +7,7 @@ describe("loader", function() {
   beforeEach(function() {
     expect.spyOn(console, "info");
 
+    this.cacheable = function() {};
     this.callback = expect.createSpy();
     this.check = expect.spyOn(installer, "check").andCallThrough();
     this.install = expect.spyOn(installer, "install");
@@ -26,6 +27,8 @@ describe("loader", function() {
       },
     };
 
+    this.query = '?{"cli":{"save":true,"saveExact":true}}';
+
     loader.call(this, this.source, this.map);
   });
 
@@ -44,12 +47,21 @@ describe("loader", function() {
     ]);
   });
 
-  it("should install missing", function() {
-    expect(this.install).toHaveBeenCalled();
-    expect(this.install.calls[0].arguments).toEqual([
-      ["missing"],
-    ]);
+  context("when calling .install", function() {
+    it("should pass dependencies as the first argument", function() {
+      expect(this.install).toHaveBeenCalled();
+      expect(this.install.calls[0].arguments[0]).toEqual(["missing"]);
+    });
+
+    it("should pass args as the second argument", function() {
+      expect(this.install).toHaveBeenCalled();
+      expect(this.install.calls[0].arguments[1]).toEqual({
+        save: true,
+        saveExact: true,
+      });
+    });
   });
+
 
   it("should callback source & map", function() {
     expect(this.callback).toHaveBeenCalled();


### PR DESCRIPTION
This would save the need for another dotfile.

Amazing loader idea, this is going to make for such a sweet development experience :+1: 