### PR TITLE
Fix spawning npm on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/ericclemmons/webpack-npm-install-loader#readme",
   "dependencies": {
     "babel-core": "^6.3.26",
+    "cross-spawn": "^2.1.4",
     "loader-utils": "^0.2.12",
     "lodash.kebabcase": "^3.0.1"
   },

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,4 +1,4 @@
-var child = require("child_process");
+var spawn = require("cross-spawn");
 var fs = require("fs");
 var kebabCase = require("lodash.kebabcase");
 var path = require("path");
@@ -75,5 +75,5 @@ module.exports.install = function install(dependencies, options) {
 
   console.info("Installing missing dependencies %s...", dependencies.join(" "));
 
-  return child.spawnSync("npm", args, { stdio: "inherit" });
+  return spawn.sync("npm", args, { stdio: "inherit" });
 };

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -1,4 +1,4 @@
-var child = require("child_process");
+var spawn = require("cross-spawn");
 var expect = require("expect");
 var installer = require("../src/installer");
 
@@ -44,7 +44,7 @@ describe("installer", function() {
 
   describe(".install", function() {
     beforeEach(function() {
-      this.spy = expect.spyOn(child, "spawnSync");
+      this.spy = expect.spyOn(spawn, "sync");
 
       expect.spyOn(console, "info");
     });


### PR DESCRIPTION
Using v1.1.0, nothing was being installed on Windows:

```
Installing missing dependencies react-fa...
webpack built 73575fc7beab59bb5df5 in 3198ms
<webpack build error logging due to missing dependency>
```

After this change:

```
Installing missing dependencies react-fa...
react-fa@4.0.0 node_modules\react-fa
└── font-awesome@4.5.0
webpack built ce9ffcc706e95ddbf288 in 7675ms
```